### PR TITLE
Fix compatibility with Gradle Enterprise Plugin 3.4

### DIFF
--- a/gradle-enterprise-conventions-gradle-plugin/build.gradle
+++ b/gradle-enterprise-conventions-gradle-plugin/build.gradle
@@ -18,7 +18,7 @@ configurations {
 
 dependencies {
 	implementation(project(":gradle-enterprise-conventions-core"))
-	compatibilityTestImplementation("com.gradle:gradle-enterprise-gradle-plugin:3.1.1")
+	compatibilityTestImplementation("com.gradle:gradle-enterprise-gradle-plugin:3.4")
 	compileOnly("com.gradle:gradle-enterprise-gradle-plugin:${gradleEnterprisePluginVersion}")
 	testImplementation("com.gradle:gradle-enterprise-gradle-plugin:${gradleEnterprisePluginVersion}")
 }

--- a/gradle-enterprise-conventions-gradle-plugin/src/main/java/io/spring/ge/conventions/gradle/GradleConfigurableBuildScan.java
+++ b/gradle-enterprise-conventions-gradle-plugin/src/main/java/io/spring/ge/conventions/gradle/GradleConfigurableBuildScan.java
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures;
 import com.gradle.scan.plugin.BuildScanDataObfuscation;
 import com.gradle.scan.plugin.BuildScanExtension;
-import com.gradle.scan.plugin.internal.api.BuildScanExtensionWithHiddenFeatures;
 import io.spring.ge.conventions.core.ConfigurableBuildScan;
 
 /**

--- a/gradle-enterprise-conventions-gradle-plugin/src/test/java/io/spring/ge/conventions/gradle/GradleConfigurableBuildScanTests.java
+++ b/gradle-enterprise-conventions-gradle-plugin/src/test/java/io/spring/ge/conventions/gradle/GradleConfigurableBuildScanTests.java
@@ -26,11 +26,11 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures;
 import com.gradle.scan.plugin.BuildResult;
 import com.gradle.scan.plugin.BuildScanDataObfuscation;
 import com.gradle.scan.plugin.BuildScanExtension;
 import com.gradle.scan.plugin.PublishedBuildScan;
-import com.gradle.scan.plugin.internal.api.BuildScanExtensionWithHiddenFeatures;
 import org.gradle.api.Action;
 import org.junit.jupiter.api.Test;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version=0.0.7-SNAPSHOT
 
-gradleEnterprisePluginVersion=3.3.3
+gradleEnterprisePluginVersion=3.4.1
 gradleEnterpriseExtensionVersion=1.5.3
 javaFormatVersion=0.0.22


### PR DESCRIPTION
The internal api was moved from one package to another in 3.4. This fixes compatibility.

Note: the conventions plugin is not backward compatible with any version lower than 3.4 anymore.
Older versions of Gradle are still supported since the api change is only in the plugin itself and not Gradle.
