### PR TITLE
Connect build to ge.spring.io to benefit from deep build insights and faster builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .classpath
 .gradle
+.idea
 .project
 .settings/
 bin/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gradle Enterprise Conventions
+# Gradle Enterprise Conventions [![Revved up by Gradle Enterprise](https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.spring.io/scans?search.rootProjectNames=gradle-enterprise-conventions-gradle-plugin)
 
 Conventions for Gradle projects that use the Gradle Enterprise instance hosted at [ge.spring.io](https://ge.spring.io).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@ version=0.0.15-SNAPSHOT
 
 gradleEnterprisePluginVersion=3.14.1
 javaFormatVersion=0.0.39
+
+org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
 	repositories {
 		mavenCentral()
 		gradlePluginPortal()
+		maven { url 'https://repo.spring.io/release' }
 	}
 	resolutionStrategy {
 		eachPlugin {
@@ -10,6 +11,11 @@ pluginManagement {
 			}
 		}
 	}
+}
+
+plugins {
+	id 'com.gradle.enterprise' version '3.14.1'
+	id 'io.spring.ge.conventions' version '0.0.14'
 }
 
 rootProject.name = 'gradle-enterprise-conventions-gradle-plugin'


### PR DESCRIPTION
This pull request connects the build to the Gradle Enterprise instance at https://ge.spring.io/. 